### PR TITLE
Add grouped Dependabot config with optional auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot configuration.
+# Groups updates into a single weekly PR per ecosystem so dependency
+# maintenance stays low-noise and easy to review. Patch/minor updates that
+# pass CI can be auto-merged via .github/workflows/dependabot-automerge.yml.
+version: 2
+updates:
+  # Core package: pyproject.toml / poetry.lock / requirements.txt at the root.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Example notebooks have their own pinned requirements.
+  - package-ecosystem: "pip"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      example-deps:
+        patterns:
+          - "*"
+
+  # Keep GitHub Actions in the CI workflows current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,30 @@
+# Auto-merge Dependabot PRs for patch and minor updates once required CI passes.
+#
+# Prerequisites (one-time repo settings, Settings > General and Settings > Branches):
+#   1. Enable "Allow auto-merge".
+#   2. Add a branch protection rule on `main` that requires status checks to pass
+#      (e.g. the ossaudit check). `gh pr merge --auto` only merges after those pass.
+# Major-version updates are intentionally left for manual review.
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch/minor updates
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reduce dependency-maintenance overhead so updates stay manageable with minimal hands-on attention:

- .github/dependabot.yml: weekly, grouped updates for the root pip project, the examples requirements, and GitHub Actions. Each ecosystem produces a single grouped PR instead of one PR per dependency.
- .github/workflows/dependabot-automerge.yml: auto-merges patch/minor Dependabot PRs once required CI passes; major bumps remain manual. Requires the repo setting "Allow auto-merge" and a branch protection rule requiring status checks (documented in the workflow header).